### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,21 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_participant(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is signed up before removing
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Team-based soccer practice, fitness, and inter-school matches",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Develop basketball fundamentals and compete in friendly games",
+        "schedule": "Tuesdays and Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+    },
+    "Painting Studio": {
+        "description": "Explore watercolor, acrylic, and mixed media painting techniques",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["isabella@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Practice acting, improvisation, and stage performance",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Build public speaking and critical thinking through structured debates",
+        "schedule": "Mondays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["elijah@mergington.edu", "james@mergington.edu"]
+    },
+    "Math Olympiad Prep": {
+        "description": "Solve advanced math problems and prepare for competitions",
+        "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 14,
+        "participants": ["lucas@mergington.edu", "benjamin@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,14 +4,27 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Escape dynamic content before injecting into HTML templates.
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch(`/activities?ts=${Date.now()}`, {
+        cache: "no-store",
+      });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +32,39 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsMarkup = details.participants.length
+          ? details.participants
+              .map(
+                (participant) => `
+                  <li class="participant-item">
+                    <span class="participant-email">${escapeHtml(participant)}</span>
+                    <button
+                      type="button"
+                      class="delete-participant-btn"
+                      data-activity="${encodeURIComponent(name)}"
+                      data-email="${encodeURIComponent(participant)}"
+                      aria-label="Remove ${escapeHtml(participant)} from ${escapeHtml(name)}"
+                      title="Remove participant"
+                    >
+                      &times;
+                    </button>
+                  </li>
+                `
+              )
+              .join("")
+          : '<li class="no-participants">No one has signed up yet.</li>';
 
         activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
+          <h4>${escapeHtml(name)}</h4>
+          <p>${escapeHtml(details.description)}</p>
+          <p><strong>Schedule:</strong> ${escapeHtml(details.schedule)}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <h5>Participants</h5>
+            <ul class="participants-list">
+              ${participantsMarkup}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +102,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +119,50 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteButton = event.target.closest(".delete-participant-btn");
+    if (!deleteButton) {
+      return;
+    }
+
+    const activity = decodeURIComponent(deleteButton.dataset.activity || "");
+    const email = decodeURIComponent(deleteButton.dataset.email || "");
+
+    if (!activity || !email) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/participants?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "Failed to unregister participant";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -61,8 +61,9 @@ section h3 {
   margin-bottom: 15px;
   padding: 15px;
   border: 1px solid #ddd;
-  border-radius: 5px;
-  background-color: #f9f9f9;
+  border-radius: 10px;
+  background: linear-gradient(160deg, #f9fbff 0%, #f4f6ff 100%);
+  box-shadow: 0 6px 14px rgba(26, 35, 126, 0.08);
 }
 
 .activity-card h4 {
@@ -72,6 +73,73 @@ section h3 {
 
 .activity-card p {
   margin-bottom: 8px;
+}
+
+.participants-section {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background-color: #ffffff;
+  border: 1px solid #dfe6ff;
+  border-radius: 8px;
+}
+
+.participants-section h5 {
+  margin-bottom: 8px;
+  color: #1a237e;
+  font-size: 0.95rem;
+}
+
+.participants-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+  color: #263238;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background-color: #f7f9ff;
+}
+
+.participant-email {
+  word-break: break-word;
+}
+
+.delete-participant-btn {
+  width: 24px;
+  height: 24px;
+  border: 1px solid #f5c6cb;
+  border-radius: 50%;
+  background-color: #fff1f2;
+  color: #b42318;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  transition: all 0.2s ease;
+}
+
+.delete-participant-btn:hover {
+  background-color: #ffe4e6;
+  border-color: #fda4af;
+  transform: scale(1.05);
+}
+
+.participants-list .no-participants {
+  color: #6b7280;
+  font-style: italic;
 }
 
 .form-group {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+
+_INITIAL_ACTIVITIES = deepcopy(app_module.activities)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset shared in-memory activity state between tests."""
+    app_module.activities = deepcopy(_INITIAL_ACTIVITIES)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)

--- a/tests/test_activities_api.py
+++ b/tests/test_activities_api.py
@@ -1,0 +1,21 @@
+def test_root_redirects_to_static_index(client):
+    response = client.get("/", follow_redirects=False)
+
+    assert response.status_code in (302, 307)
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities_returns_expected_shape(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, dict)
+    assert "Chess Club" in payload
+
+    chess = payload["Chess Club"]
+    assert "description" in chess
+    assert "schedule" in chess
+    assert "max_participants" in chess
+    assert "participants" in chess
+    assert isinstance(chess["participants"], list)

--- a/tests/test_signup_and_unregister.py
+++ b/tests/test_signup_and_unregister.py
@@ -1,0 +1,72 @@
+def test_signup_adds_participant(client):
+    email = "new-student@mergington.edu"
+
+    signup_response = client.post(
+        "/activities/Chess%20Club/signup",
+        params={"email": email},
+    )
+
+    assert signup_response.status_code == 200
+    assert signup_response.json()["message"] == f"Signed up {email} for Chess Club"
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()["Chess Club"]["participants"]
+    assert email in participants
+
+
+def test_signup_duplicate_participant_returns_400(client):
+    email = "michael@mergington.edu"
+
+    response = client.post(
+        "/activities/Chess%20Club/signup",
+        params={"email": email},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_unknown_activity_returns_404(client):
+    response = client.post(
+        "/activities/Unknown%20Activity/signup",
+        params={"email": "someone@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_removes_participant(client):
+    email = "daniel@mergington.edu"
+
+    unregister_response = client.delete(
+        "/activities/Chess%20Club/participants",
+        params={"email": email},
+    )
+
+    assert unregister_response.status_code == 200
+    assert unregister_response.json()["message"] == f"Unregistered {email} from Chess Club"
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()["Chess Club"]["participants"]
+    assert email not in participants
+
+
+def test_unregister_unknown_activity_returns_404(client):
+    response = client.delete(
+        "/activities/Unknown%20Activity/participants",
+        params={"email": "someone@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_non_participant_returns_404(client):
+    response = client.delete(
+        "/activities/Chess%20Club/participants",
+        params={"email": "not-registered@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Student is not signed up for this activity"


### PR DESCRIPTION
This pull request introduces several new features and improvements to the student activities app, including new activity options, participant management (signup and removal), enhanced UI for participant lists, and robust testing. The most important changes are grouped below:

**Backend: Activity and Participant Management**

* Added several new activities (`Soccer Team`, `Basketball Club`, `Painting Studio`, `Drama Club`, `Debate Team`, `Math Olympiad Prep`) to the `activities` dictionary in `src/app.py`, each with descriptions, schedules, and participant lists.
* Implemented participant removal endpoint (`unregister_participant`) in `src/app.py`, allowing students to be unregistered from activities via a DELETE request, with error handling for unknown activities and non-participants.
* Improved signup logic to prevent duplicate participant registration for an activity.

**Frontend: UI and Participant List Enhancements**

* Updated `src/static/app.js` to display participant lists for each activity, including a delete button for each participant; added HTML escaping for dynamic content and improved activity fetching logic.
* Added frontend logic for participant removal, including event handling for delete buttons and feedback messages.
* Refreshed activities UI after signup/removal to reflect changes immediately.
* Enhanced styles for activity cards and participant lists in `src/static/styles.css`, including new section styling, participant list formatting, and delete button appearance. [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2L64-R66) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R78-R144)

**Testing: API and State Management**

* Added fixtures in `tests/conftest.py` to reset in-memory activity state between tests and provide a test client.
* Added tests for core API endpoints: root redirect, activity listing, signup (including duplicate and unknown activity cases), and participant removal (including unknown activity and non-participant cases). [[1]](diffhunk://#diff-eafc5698f9b6a7272e496525da3098f0fc56b9c19e4ccb6eaf54108bbac9f0ceR1-R21) [[2]](diffhunk://#diff-249529d214189a8f5b5b5739f97261bbbc0af96f243dffd62cbc77f870a949a8R1-R72)